### PR TITLE
Add setting and button to select configuration before launch debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,21 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Prevents the debug start icon from showing when the debugger is not running. The rest of the controls will show when a debugger is started from another avenue."
+				},
+				"debugControlsInTitlebar.selectConfigurationBeforeRun": {
+					"type": "string",
+					"enum": [
+						"never",
+						"always",
+						"button"
+					],
+					"enumDescriptions": [
+						"Never",
+						"Always",
+						"Show additional button to select configuration"
+					],
+					"default": "never",
+					"description": "Select a configuration before starting a debugger."
 				}
 			}
 		},
@@ -61,6 +76,12 @@
 				"command": "debug-in-titlebar.debug-start",
 				"title": "Start Debug",
 				"icon": "$(debug-start)",
+				"enablement": "debugState != 'initializing'"
+			},
+			{
+				"command": "debug-in-titlebar.debug-select",
+				"title": "Select configuration and start",
+				"icon": "$(debug-line-by-line)",
 				"enablement": "debugState != 'initializing'"
 			},
 			{
@@ -105,6 +126,11 @@
 					"group": "navigation@1999901",
 					"when": "debuggersAvailable && !config.debugControlsInTitlebar.hideDebugStart && !inDebugMode || debugState == 'initializing'"
 
+				},
+				{
+					"command": "debug-in-titlebar.debug-select",
+					"group": "navigation@1999901",
+					"when": "debuggersAvailable && !config.debugControlsInTitlebar.hideDebugStart && config.debugControlsInTitlebar.selectConfigurationBeforeRun === 'button' && !inDebugMode || debugState == 'initializing'"
 				},
 				{
 					"command": "debug-in-titlebar.debug-pause",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,18 @@ export function activate(context: vscode.ExtensionContext) {
 	let debugStart = vscode.commands.registerCommand(
 		`debug-in-titlebar.debug-start`,
 		() => {
+			let config = vscode.workspace.getConfiguration('debugControlsInTitlebar');
+			if (config.get('selectConfigurationBeforeRun') === 'always') {
+				vscode.commands.executeCommand("workbench.action.debug.selectandstart");
+				return;
+			}
 			vscode.commands.executeCommand("workbench.action.debug.start");
+		}
+	);
+	let debugSelect = vscode.commands.registerCommand(
+		`debug-in-titlebar.debug-select`,
+		() => {
+			vscode.commands.executeCommand("workbench.action.debug.selectandstart");
 		}
 	);
 	let debugStop = vscode.commands.registerCommand(
@@ -70,6 +81,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		debugRestart,
 		debugStart,
+		debugSelect,
 		debugStop,
 		debugContinue,
 		debugStepInto,


### PR DESCRIPTION
This PR add setting to allow users to select launch configuration, before start debug session.

It is 3 options:
- **never** - don't ask user what configuration will use
- **always** - ask user, when triggered `debug-in-titlebar.debug-start` command
- **button** - add separated button to select configuration

![configuration](https://github.com/EverlastEngineering/debugInTitlebar/assets/12231048/164f7785-d43e-4c33-a157-2d6c6395dae2)
![button](https://github.com/EverlastEngineering/debugInTitlebar/assets/12231048/0dcd6c49-21c7-436e-a92e-920d851fcc37)

